### PR TITLE
Helper module to extract the ebuttm:documentStartOfProgramme value in…

### DIFF
--- a/modules/TT-Helper/extract_start_of_programme/README.md
+++ b/modules/TT-Helper/extract_start_of_programme/README.md
@@ -1,0 +1,16 @@
+# extract_start_of_programme
+The extract_start_of_programme module takes as input an EBU-TT document and outputs the value of ebuttm:documentStartOfProgramme converted to seconds.  
+
+##Prerequisites
+- an XSLT 1.0 processor (e.g. SAXON 6.5.5 or higher)
+
+##Usage
+The extract_start_of_programme.xsl has no parameter.
+
+
+## EXAMPLES
+    java -jar saxon9he.jar -s:ebutt-part1.xml -xsl:extract_start_of_programme.xsl
+
+(or passing output value into EBU-TT2EBU-TT-D.xslt in bash shell):
+
+    java -cp saxon9he.jar net.sf.saxon.Transform -s:ebutt-part1.xml -xsl:EBU-TT2EBU-TT-D.xslt -o:ebutt-d.xml offsetInSeconds=$(java -jar saxon9he.jar -s:ebutt-part1.xml -xsl:extract_start_of_programme.xsl)

--- a/modules/TT-Helper/extract_start_of_programme/extract_start_of_programme.xsl
+++ b/modules/TT-Helper/extract_start_of_programme/extract_start_of_programme.xsl
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+    xmlns:xs="http://www.w3.org/2001/XMLSchema"
+    xmlns:tt="http://www.w3.org/ns/ttml"
+    xmlns:ebuttm="urn:ebu:tt:metadata"
+    xmlns:fn="http://www.w3.org/2005/xpath-functions"
+    exclude-result-prefixes="xs"
+    version="2.0">
+    <xsl:output omit-xml-declaration="yes" method="text" exclude-result-prefixes="#all"></xsl:output>
+    <xsl:template match="/">
+        <xsl:value-of select="3600*fn:number(fn:tokenize(tt:tt/tt:head/tt:metadata/ebuttm:documentMetadata/ebuttm:documentStartOfProgramme,':')[1])+60*fn:number(fn:tokenize(tt:tt/tt:head/tt:metadata/ebuttm:documentMetadata/ebuttm:documentStartOfProgramme,':')[2])+fn:number(fn:tokenize(tt:tt/tt:head/tt:metadata/ebuttm:documentMetadata/ebuttm:documentStartOfProgramme,':')[3])"/>       
+    </xsl:template>
+</xsl:stylesheet>


### PR DESCRIPTION
… seconds

Probably not the tidiest possible XSL but functional. Output may be
passed into EBU-TT2EBU-TT-D.xslt for conversion from smpte timebase to
media timebase using the `ebuttm:documentStartOfProgramme` value.
